### PR TITLE
Fix a regression on beta Rust

### DIFF
--- a/src/activation.rs
+++ b/src/activation.rs
@@ -216,7 +216,7 @@ mod test {
 
     #[test]
     fn softmax_test() {
-        let items = vec![1.0, 2.0, 3.0];
+        let items = vec![1.0f64, 2.0, 3.0];
         let res = Activation::softmax(items[0], items);
         assert!((res - 0.09003057).abs() < 0.001)
         // close eneough.
@@ -224,14 +224,14 @@ mod test {
 
     #[test]
     fn softmax_derivative_test() {
-        let classes = vec![3.0, 4.0, 5.0];
+        let classes = vec![3.0f64, 4.0, 5.0];
         let res = Activation::softmax_derivative(0, classes);
         assert!((res[0] - 0.08192506).abs() < 0.001);
     }
 
     #[test]
     fn softmax_derivative_vector_test() {
-        let classes = vec![1.0, 2.0, 3.0];
+        let classes = vec![1.0f64, 2.0, 3.0];
         let res = Activation::softmax_derivative(0, classes);
         println!("{res:?}");
 


### PR DESCRIPTION
This bit of code relies on behavior that will no longer work in Rust 1.79, which is currently in beta. Since this crate was the only regression, the behavior change was considered acceptable, but does mean that this crate has a minor breakage in tests. 

Add a concrete type to the vector to correct for this behavior change. 

See the context here: https://github.com/rust-lang/rust/issues/125198